### PR TITLE
Show toc on top of GitHub content

### DIFF
--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -16,10 +16,6 @@ body {
   transition: $animation-time 0s margin-right ease-in-out;
 }
 
-body[data-github-markdown-toc-open] {
-  margin-right: $nav-width;
-}
-
 .Header {
   transition: $animation-time 0s padding-right ease-in-out;
 


### PR DESCRIPTION
I find the current sliding animation quite disruptive with the new full-width GitHub UI. This change avoids pushing GitHub content away and simply just lay the toc on top and nothing else in the page moves around.

Give this a try and see if you'd prefer this :) Or maybe add an option (though I imagine it would require a lot more changes)?

Thanks for creating this extension, it solved a major paint point for me ❤️ .